### PR TITLE
Super linter uses docker image with JVM11 for running linters

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version-file: .java-version
+          check-latest: true
+
       # Runs the Super-Linter action
       - name: Run Super-Linter
         uses: github/super-linter/slim@v4

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          check-latest: true
-
       # Runs the Super-Linter action
       - name: Run Super-Linter
         uses: github/super-linter/slim@v4

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version-file: .java-version
-          check-latest: true
-
       # Runs the Super-Linter action
       - name: Run Super-Linter
         uses: github/super-linter/slim@v4
@@ -33,6 +26,8 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           DEFAULT_BRANCH: master
           VALIDATE_JAVA: false
+          # Java17 can't be validated https://github.com/github/super-linter/blob/main/Dockerfile#L78
+          VALIDATE_GOOGLE_JAVA_FORMAT: false
           SQLFLUFF_CONFIG_FILE: .sqlfluff
           FILTER_REGEX_EXCLUDE: .*gradlew
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# java-template
+# POC for Retrofit and JOOQ
+
 POC project for CRUD using JOOQ and retrofit along with resilience4j


### PR DESCRIPTION
Linting of java17 is not possible due to Docker file configuration of super-linter